### PR TITLE
MAINT: Use an unconditional conversion to array when broadcating input

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,13 +13,15 @@ source_files = [
     "src/pgm_common.c",
 ]
 
+
 # https://numpy.org/devdocs/reference/random/examples/cython/setup.py.html
+include_path = np.get_include()
 extensions = [
     Extension(
         "_polyagamma",
         source_files,
-        include_dirs=[np.get_include(), "./include"],
-        library_dirs=[join(np.get_include(), '..', '..', 'random', 'lib')],
+        include_dirs=[include_path, "./include"],
+        library_dirs=[join(include_path, '..', '..', 'random', 'lib')],
         libraries=['npyrandom'],
         define_macros=[('NPY_NO_DEPRECATED_API', 0)],
         extra_compile_args=['-std=c99']

--- a/examples/c_polyagamma.c
+++ b/examples/c_polyagamma.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
 
 typedef struct {uint64_t s[2];} xrs128p_random_t;
 

--- a/include/pgm_random.h
+++ b/include/pgm_random.h
@@ -50,4 +50,16 @@ double pgm_random_polyagamma(bitgen_t* bitgen_state, double h, double z,
  */
 void pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
                                 sampler_t method, size_t n, double* out);
+
+/*
+ * Generate n samples from a PG(h[i], z[i]) distribution, where h and z are
+ * arrays.
+ *
+ * h, z and out must be at least `n` in length. Only the first n elements of
+ * `out` will be filled.
+ */
+void pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h,
+                                 const double* z, sampler_t method, size_t n,
+                                 double* restrict out);
+
 #endif

--- a/include/pgm_random.h
+++ b/include/pgm_random.h
@@ -22,7 +22,10 @@ typedef enum {GAMMA, DEVROYE, ALTERNATE, SADDLE, HYBRID} sampler_t;
  *  method : sampler_t
  *      The type of method to use when sampling. Must be one of {GAMMA,
  *      DEVROYE, ALTERNATE, HYBRID}. The HYBRID sampler automatically chooses
- *      the appropriate method using the parameter values.
+ *      the appropriate method using the parameter values. The DEVROYE method
+ *      can only be used with positive integer values of h. If h is a not a
+ *      positive whole number, then it will be truncated to an integer before
+ *      sampling.
  *
  *  References
  *  ----------

--- a/polyagamma/_polyagamma.pyx
+++ b/polyagamma/_polyagamma.pyx
@@ -40,21 +40,6 @@ cdef bint is_sequence(object x):
     return out
 
 
-cdef np.broadcast broadcast_params(object h, object z):
-    """
-    Broadcast the inputs into a multiIterator object.
-
-    the input can be a scalar, list, tuple or numpy array or array_like object.
-    """
-    cdef bint is_h_seq = is_sequence(h)
-    cdef bint is_z_seq = is_sequence(z)
-
-    h = <double>h if not is_h_seq else np.PyArray_FROM_OT(h, np.NPY_DOUBLE)
-    z = <double>z if not is_z_seq else np.PyArray_FROM_OT(z, np.NPY_DOUBLE)
-
-    return np.PyArray_MultiIterNew2(h, z)
-
-
 cdef dict METHODS = {
     "gamma": GAMMA,
     "devroye": DEVROYE,
@@ -155,9 +140,12 @@ class Generator(np.random.Generator):
                 stype = METHODS[method]
 
         if is_sequence(h) or is_sequence(z):
-            if not disable_checks and np.any(np.asarray(h) <= zero):
+            h = np.PyArray_FROM_OT(h, np.NPY_DOUBLE)
+            z = np.PyArray_FROM_OT(z, np.NPY_DOUBLE)
+            if not disable_checks and np.any(h <= zero):
                 raise ValueError("values of `h` must be positive")
-            bcast = broadcast_params(h, z)
+
+            bcast = np.PyArray_MultiIterNew2(h, z)
             if has_out and out.shape[0] != bcast.size:
                 raise ValueError(
                     "`out` must have the same total size as the broadcasted "

--- a/polyagamma/_polyagamma.pyx
+++ b/polyagamma/_polyagamma.pyx
@@ -61,8 +61,8 @@ class Generator(np.random.Generator):
         Parameters
         ----------
         h : scalar or sequence, optional
-            The `h` parameter as described in [1]_. The value(s) must be
-            positive. Defaults to 1.
+            The shape parameter of the distribution as described in [1]_.
+            The value(s) must be positive. Defaults to 1.
         z : scalar or sequence, optional
             The exponential tilting parameter as described in [1]_.
             Defaults to 0.
@@ -81,7 +81,8 @@ class Generator(np.random.Generator):
             sampler is used that picks a method based on the value of `h`.
             A legal value must be one of {"gamma", "devroye", "alternate"}. If
             the "alternate" method is used, then the value of `h` must be no
-            less than 1.
+            less than 1. If the "devroye" method is used, the `h` must be a
+            positive integer.
         disable_checks : bool, optional
             Whether to check that the `h` parameter contains only positive
             values(s). Disabling may give a performance gain, but may result
@@ -136,6 +137,8 @@ class Generator(np.random.Generator):
                 raise ValueError(f"`method` must be one of {set(METHODS)}")
             elif method == "alternate" and h < 1:
                 raise ValueError("alternate method must have h >=1")
+            elif method == "devroye" and not float(h).is_integer():
+                raise ValueError("devroye method must have integer values for h")
             else:
                 stype = METHODS[method]
 

--- a/src/pgm_devroye.c
+++ b/src/pgm_devroye.c
@@ -124,7 +124,7 @@ random_jacobi(bitgen_t* bitgen_state, double z)
  * sample from J*(n, z), where n is a positive integer greater than 1
  */
 static NPY_INLINE double
-random_jacobi_n(bitgen_t *bitgen_state, size_t n, double z)
+random_jacobi_n(bitgen_t *bitgen_state, uint64_t n, double z)
 {
     double out = 0;
     for (size_t i = n; i--; )
@@ -164,21 +164,14 @@ random_polyagamma_gamma_conv(bitgen_t* bitgen_state, double h, double z)
 }
 
 /*
- * Sample from Polya-Gamma PG(h, z) using the Devroye method
+ * Sample from Polya-Gamma PG(n, z) using the Devroye method, where n is a
+ * positive integer.
  */
 double
-random_polyagamma_devroye(bitgen_t *bitgen_state, double h, double z)
+random_polyagamma_devroye(bitgen_t *bitgen_state, uint64_t n, double z)
 {
     z = 0.5 * (z < 0 ? fabs(z) : z);
-
-    if (h < 1)
-        return 0.25 * gamma_convolution_approx(bitgen_state, h, z);
-
-    double out, fract_part, int_part;
-    // split h into its integer and fractional parts
-    fract_part = modf(h, &int_part);
-    out = random_jacobi_n(bitgen_state, (size_t)int_part, z);
-    if (fract_part > 0)
-        out += gamma_convolution_approx(bitgen_state, fract_part, z);
-    return 0.25 * out;
+    if (n > 1)
+        return 0.25 * random_jacobi_n(bitgen_state, n, z);
+    return 0.25 * random_jacobi(bitgen_state, z);
 }

--- a/src/pgm_devroye.h
+++ b/src/pgm_devroye.h
@@ -3,7 +3,8 @@
 
 #include "pgm_common.h"
 
-double random_polyagamma_devroye(bitgen_t *bitgen_state, double h, double z);
+
+double random_polyagamma_devroye(bitgen_t *bitgen_state, uint64_t n, double z);
 double random_polyagamma_gamma_conv(bitgen_t* bitgen_state, double h, double z);
 
 #endif

--- a/src/pgm_random.c
+++ b/src/pgm_random.c
@@ -13,13 +13,11 @@ random_polyagamma_hybrid(bitgen_t* bitgen_state, double h, double z)
         return random_polyagamma_gamma_conv(bitgen_state, h, z);
     }
     else {
-        // the devroye method runs faster for integer values of `h` and the
-        // alternate method is faster for non-integer values.
         double fract_part, int_part;
         fract_part = modf(h, &int_part);
         if (fract_part > 0)
             return random_polyagamma_alternate(bitgen_state, h, z);
-        return random_polyagamma_devroye(bitgen_state, h, z);
+        return random_polyagamma_devroye(bitgen_state, (uint64_t)int_part, z);
     }
 }
 
@@ -32,7 +30,7 @@ pgm_random_polyagamma(bitgen_t* bitgen_state, double h, double z, sampler_t meth
         case GAMMA:
             return random_polyagamma_gamma_conv(bitgen_state, h, z);
         case DEVROYE:
-            return random_polyagamma_devroye(bitgen_state, h, z);
+            return random_polyagamma_devroye(bitgen_state, (uint64_t)h, z);
         case ALTERNATE:
             return random_polyagamma_alternate(bitgen_state, h, z);
         default:

--- a/src/pgm_random.c
+++ b/src/pgm_random.c
@@ -48,3 +48,13 @@ pgm_random_polyagamma_fill(bitgen_t* bitgen_state, double h, double z,
     for (size_t i = n; i--; )
         out[i] = pgm_random_polyagamma(bitgen_state, h, z, method);
 }
+
+
+NPY_INLINE void
+pgm_random_polyagamma_fill2(bitgen_t* bitgen_state, const double* h,
+                            const double* z, sampler_t method, size_t n,
+                            double* restrict out)
+{
+    for (size_t i = n; i--; )
+        out[i] = pgm_random_polyagamma(bitgen_state, h[i], z[i], method);
+}

--- a/tests/test_polyagamma.py
+++ b/tests/test_polyagamma.py
@@ -66,6 +66,11 @@ def test_polyagamma():
     # raise error for values less than 1 with alternate method
     with pytest.raises(ValueError):
         rng.polyagamma(0.9, method="alternate")
+    # raise an error when using devroye with non-integer values of h
+    with pytest.raises(ValueError):
+        rng.polyagamma(2.0000000001, method="devroye")
+    # should work for whole numbers is 2.000000 == 2
+    rng.polyagamma(2.0000000000, method="devroye")
 
     # raise error when passed a none-keyword args after the first 2
     with pytest.raises(TypeError, match="takes at most 3 positional arguments"):


### PR DESCRIPTION
- Use an unconditional conversion to array when broadcating input
- Add a version of the array fill function that takes array parameter input.
- Remove duplicated numpy get_include() function call in build module
- restrict `devroye` method to integer values of the scale parameter (as intended in the paper).